### PR TITLE
Fix datetime to date

### DIFF
--- a/departments.ps1
+++ b/departments.ps1
@@ -1,7 +1,7 @@
 ######################################################
 # HelloID-Conn-Prov-Source-Elanza-Departments
 #
-# Version: 1.1.0
+# Version: 1.1.1
 ######################################################
 
 # Initialize default values

--- a/persons.ps1
+++ b/persons.ps1
@@ -151,9 +151,13 @@ try {
 
         foreach ($shift in $worker.shifts) {
             if (![string]::IsNullOrEmpty($shift.StartAt)) {
-                $shiftStart = [DateTime]::ParseExact($shift.startAt, "MM/dd/yyyy HH:mm:ss", [System.Globalization.CultureInfo]::InvariantCulture)
+                $shiftStart = [DateTime]::ParseExact($shift.startAt, "MM/dd/yyyy HH:mm:ss", [System.Globalization.CultureInfo]::InvariantCulture) #Shift needs convert from datetime to datew
+                
+                # shiftStart           # should be date with time 00:00:00
+                # detailsStartDate     # should be date with time 00:00:00
+                # detailsEndDate        # should be date with time 00:00:00
 
-                if ($shiftStart -ge $detailsStartDate -and $shiftStart -le $detailsEndDate) {
+                if ($shiftStart -ge $detailsStartDate -and $shiftStart -le $detailsEndDate) {           #todo: comparison needs convert from datetime to date
                     $shift | Add-Member -MemberType 'NoteProperty' -Name 'ExternalId'  -Value $shift.uuid
                     $shift | Add-Member -MemberType 'NoteProperty' -Name 'Type'        -Value 'ActiveShift'
 
@@ -199,10 +203,23 @@ try {
                         }
                     }
                     $shift | Add-Member -MemberType 'NoteProperty' -Name 'SkillNames' -Value ($shiftSkills.name -join ';')
+                    
+                    # Make sure that startAt and endAt are returned as a date string
+                    if (![string]::IsNullOrEmpty($shift.startAt)){
+                        $shift.startAt = $shift.startAt.ToString('yyyy-MM-dd')
+                    }
+                    if (![string]::IsNullOrEmpty($shift.endAt)){
+                        $shift.endAt = $shift.endAt.ToString('yyyy-MM-dd')
+                    }
 
                     $contracts.Add($shift)
                 }
-                elseif ($shiftStart -ge $historyStartDate -and $shiftStart -le $historyEndDate) {
+                
+                # shiftStart           # should be date with time 00:00:00
+                # historyStartDate     # should be date with time 00:00:00
+                # historyEndDate        # should be date with time 00:00:00
+                
+                elseif ($shiftStart -ge $historyStartDate -and $shiftStart -le $historyEndDate) {       #historyStartDate = date; historyEndDate = date; shiftStart = datetime; 
                     $historicalShiftContract['Shifts'].Add($shift)
                 }
             }

--- a/persons.ps1
+++ b/persons.ps1
@@ -1,26 +1,27 @@
 ##################################################
 # HelloID-Conn-Prov-Source-Elanza-Persons
-#
-# Version: 1.1.0
+# Version: 1.1.1
 ##################################################
-# Initialize default values
+
+# Load configuration
 $config = $configuration | ConvertFrom-Json
 
-# Set debug logging
+# Verbose logging when debug is enabled
 switch ($($config.IsDebug)) {
     $true { $VerbosePreference = 'Continue' }
     $false { $VerbosePreference = 'SilentlyContinue' }
 }
 
-# Keep track of retrieved products
+# Cache for retrieved products
 $retrievedProducts = @{}
 
 #region functions
+
+# Get product details by ID (cached)
 function Get-ElanzaProductById {
     [CmdletBinding()]
     param (
-        [Parameter()]
-        $Id
+        [Parameter()] $Id
     )
 
     if (-not $retrievedProducts.ContainsKey($Id)) {
@@ -30,13 +31,12 @@ function Get-ElanzaProductById {
     Write-Output $retrievedProducts[$Id]
 }
 
+# Perform Elanza API call
 function Invoke-ElanzaRestMethod {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Uri
+        [string] $Uri
     )
     process {
         try {
@@ -63,13 +63,14 @@ function Invoke-ElanzaRestMethod {
     }
 }
 
+# Create readable error object from HTTP errors
 function Resolve-ElanzaError {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
-        [object]
-        $ErrorObject
+        [object] $ErrorObject
     )
+
     process {
         $httpErrorObj = [PSCustomObject]@{
             ScriptLineNumber = $ErrorObject.InvocationInfo.ScriptLineNumber
@@ -80,61 +81,48 @@ function Resolve-ElanzaError {
 
         try {
             $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
-            $errorMessage = (($ErrorObject.ErrorDetails.Message | ConvertFrom-Json)).message
-            $httpErrorObj.FriendlyMessage = $errorMessage
+            $httpErrorObj.FriendlyMessage = (($ErrorObject.ErrorDetails.Message | ConvertFrom-Json)).message
         }
         catch {
-            $httpErrorObj.FriendlyMessage = "Received an unexpected response. The JSON could not be converted, error: [$($_.Exception.Message)]. Original error from web service: [$($ErrorObject.Exception.Message)]"
+            $httpErrorObj.FriendlyMessage = "Received an unexpected response: [$($_.Exception.Message)]. Original: [$($ErrorObject.Exception.Message)]"
         }
+
         Write-Output $httpErrorObj
     }
 }
 #endregion
 
-
 try {
-    # Get all departments
-    $departments = (Invoke-ElanzaRestMethod -Uri "departments").departments
-
-    # Sort departments on uuid (to make sure the order is always the same)
-    $departments = $departments | Sort-Object -Property uuid
-
-    # Group on uuid (to match to shifts)
+    # Retrieve and group departments
+    $departments = (Invoke-ElanzaRestMethod -Uri "departments").departments |
+    Sort-Object -Property uuid
     $departmentsGrouped = $departments | Group-Object uuid -AsString -AsHashTable
 
-    # Get all skills
-    $skills = (Invoke-ElanzaRestMethod -Uri "skills").skills
-
-    # Sort skills on uuid (to make sure the order is always the same)
-    $skills = $skills | Sort-Object -Property uuid
-
-    # Group on uuid (to match to shifts)
+    # Retrieve and group skills
+    $skills = (Invoke-ElanzaRestMethod -Uri "skills").skills |
+    Sort-Object -Property uuid
     $skillsGrouped = $skills | Group-Object uuid -AsString -AsHashTable
 
-    # Get all workers with their shifts
+    # Get workers with shifts for defined period
     $historicalDays = (Get-Date).ToUniversalTime().AddDays( - $($config.HistoricalDays))
     $futureDays = (Get-Date).ToUniversalTime().AddDays($($config.FutureDays))
     $workers = (Invoke-ElanzaRestMethod -Uri "plannedWorkers?from=$($historicalDays.ToString('yyyy-MM-ddTHH:mm:ssZ'))&to=$($futureDays.ToString('yyyy-MM-ddTHH:mm:ssZ'))").workers
 
     foreach ($worker in $workers) {
+        # Work with date-only boundaries
         $detailsStartDate = (Get-Date).ToUniversalTime().AddDays( - $($config.ShiftDetailsStart)).Date
-        $detailsEndDate = $futureDays
+        $detailsEndDate = $futureDays.Date
+        $historyStartDate = $historicalDays.Date
+        $historyEndDate = $detailsStartDate.AddDays(-1)
 
-        $historyStartDate = $historicalDays
-        $historyEndDate = (Get-Date $detailsStartDate).ToUniversalTime().AddDays(-1).Date
-
-        # Create an empty list that will hold all shifts (contracts)
+        # Shifts list
         $contracts = [System.Collections.Generic.List[object]]::new()
 
-        # Create the object that will hold all historical data as one aggregated object with a custom type
+        # Historical aggregate (prevents mapping issues on empty dates)
         $historicalShiftContract = @{
-            ExternalId            = $($worker.worker.workerNumber)
+            ExternalId            = $worker.worker.workerNumber
             Shifts                = [System.Collections.Generic.List[object]]::new()
             Type                  = 'HistoricalShift'
-
-            # Add the same fields as for shift. Otherwise, the HelloID mapping will fail
-            # The value of both the 'startAt' and 'endAt' cannot be null. If empty, HelloID is unable
-            # to determine the start/end date, resulting in the contract marked as 'active'.
             startAt               = $historyStartDate.ToString('yyyy-MM-dd')
             endAt                 = $historyEndDate.ToString('yyyy-MM-dd')
             title                 = 'unavailable'
@@ -150,87 +138,66 @@ try {
         $contracts.Add($historicalShiftContract)
 
         foreach ($shift in $worker.shifts) {
-            if (![string]::IsNullOrEmpty($shift.StartAt)) {
-                $shiftStart = [DateTime]::ParseExact($shift.startAt, "MM/dd/yyyy HH:mm:ss", [System.Globalization.CultureInfo]::InvariantCulture) #Shift needs convert from datetime to datew
-                
-                # shiftStart           # should be date with time 00:00:00
-                # detailsStartDate     # should be date with time 00:00:00
-                # detailsEndDate        # should be date with time 00:00:00
-
-                if ($shiftStart -ge $detailsStartDate -and $shiftStart -le $detailsEndDate) {           #todo: comparison needs convert from datetime to date
-                    $shift | Add-Member -MemberType 'NoteProperty' -Name 'ExternalId'  -Value $shift.uuid
-                    $shift | Add-Member -MemberType 'NoteProperty' -Name 'Type'        -Value 'ActiveShift'
-
-                    # Enhance shift with product for extra information, such as: name - adjust to meet your needs
-                    # As there is no 'Get all' API for products, we need to call the API for each product
-                    if (-not[string]::IsNullOrEmpty($shift.productUuid)) {
-                        $shiftProduct = Get-ElanzaProductById -Id $shift.productUuid
-                    }
-                    if ($null -ne $shiftProduct) {
-                        # In case multiple are found with the same ID, we always select the first one in the array
-                        $shiftProduct = $shiftProduct | Select-Object -First 1
-
-                        if (![string]::IsNullOrEmpty($shiftProduct)) {
-                            $shift | Add-Member -MemberType 'NoteProperty' -Name 'ProductName' -Value $shiftProduct.name
-                            $shift | Add-Member -MemberType 'NoteProperty' -Name 'ProductHrFunctionCode' -Value $shiftProduct.hrFunctionCode
-                        }
-                    }
-
-                    # Enhance shift with department for extra information, such as: name and code - adjust to meet your needs
-                    $shiftDepartment = $departmentsGrouped["$($shift.departmentUuid)"]
-                    if ($null -ne $shiftDepartment) {
-                        # In case multiple are found with the same ID, we always select the first one in the array
-                        $shiftDepartment = $shiftDepartment | Select-Object -First 1
-
-                        if (![string]::IsNullOrEmpty($shiftDepartment)) {
-                            $shift | Add-Member -MemberType 'NoteProperty' -Name 'DepartmentName' -Value $shiftDepartment.name
-                            $shift | Add-Member -MemberType 'NoteProperty' -Name 'DepartmentCode' -Value $shiftDepartment.code
-                            $shift | Add-Member -MemberType 'NoteProperty' -Name 'DepartmentBrandName' -Value $shiftDepartment.brandName
-                        }
-                    }
-
-                    # Enhance shift with skills for extra information, such as: name - adjust to meet your needs
-                    $shiftSkills = [System.Collections.Generic.List[object]]::new()
-                    foreach ($skillUuid in $shift.skillUuids) {
-                        $shiftSkill = $skillsGrouped["$($skillUuid)"]
-                        if ($null -ne $shiftSkill) {
-                            # In case multiple are found with the same ID, we always select the first one in the array
-                            $shiftSkill = $shiftSkill | Select-Object -First 1
-                        
-                            if (![string]::IsNullOrEmpty($shiftSkill)) {
-                                $shiftSkills.Add($shiftSkill)
-                            }
-                        }
-                    }
-                    $shift | Add-Member -MemberType 'NoteProperty' -Name 'SkillNames' -Value ($shiftSkills.name -join ';')
-                    
-                    # Make sure that startAt and endAt are returned as a date string
-                    if (![string]::IsNullOrEmpty($shift.startAt)){
-                        $shift.startAt = $shift.startAt.ToString('yyyy-MM-dd')
-                    }
-                    if (![string]::IsNullOrEmpty($shift.endAt)){
-                        $shift.endAt = $shift.endAt.ToString('yyyy-MM-dd')
-                    }
-
-                    $contracts.Add($shift)
-                }
-                
-                # shiftStart           # should be date with time 00:00:00
-                # historyStartDate     # should be date with time 00:00:00
-                # historyEndDate        # should be date with time 00:00:00
-                
-                elseif ($shiftStart -ge $historyStartDate -and $shiftStart -le $historyEndDate) {       #historyStartDate = date; historyEndDate = date; shiftStart = datetime; 
-                    $historicalShiftContract['Shifts'].Add($shift)
-                }
+            if ([string]::IsNullOrEmpty($shift.StartAt)) {
+                Write-Verbose "Attribute [startAt] is empty for shift [$($shift.uuid)] worker [$($worker.worker.workerNumber)]."
+                continue
             }
-            else {
-                Write-Verbose "Attribute: [startAt] is empty. Import failed for shift with id: [$($shift.uuid)] and worker: [$($worker.worker.workerNumber)]."
+
+            # Parse start as date-only
+            $shiftStart = [DateTime]::ParseExact($shift.startAt, "MM/dd/yyyy HH:mm:ss", [System.Globalization.CultureInfo]::InvariantCulture).Date
+
+            # Active shifts window
+            if ($shiftStart -ge $detailsStartDate -and $shiftStart -le $detailsEndDate) {
+                $shift | Add-Member -MemberType NoteProperty -Name ExternalId -Value $shift.uuid
+                $shift | Add-Member -MemberType NoteProperty -Name Type       -Value 'ActiveShift'
+
+                # Product info
+                if (-not [string]::IsNullOrEmpty($shift.productUuid)) {
+                    $shiftProduct = Get-ElanzaProductById -Id $shift.productUuid | Select-Object -First 1
+                    if ($null -ne $shiftProduct) {
+                        $shift | Add-Member -MemberType NoteProperty -Name ProductName           -Value $shiftProduct.name
+                        $shift | Add-Member -MemberType NoteProperty -Name ProductHrFunctionCode -Value $shiftProduct.hrFunctionCode
+                    }
+                }
+
+                # Department info
+                $shiftDepartment = $departmentsGrouped["$($shift.departmentUuid)"] | Select-Object -First 1
+                if ($null -ne $shiftDepartment) {
+                    $shift | Add-Member -MemberType NoteProperty -Name DepartmentName      -Value $shiftDepartment.name
+                    $shift | Add-Member -MemberType NoteProperty -Name DepartmentCode      -Value $shiftDepartment.code
+                    $shift | Add-Member -MemberType NoteProperty -Name DepartmentBrandName -Value $shiftDepartment.brandName
+                }
+
+                # Skills → explicit collection
+                $shiftSkills = [System.Collections.Generic.List[object]]::new()
+                foreach ($skillUuid in $shift.skillUuids) {
+                    $skill = $skillsGrouped["$($skillUuid)"] | Select-Object -First 1
+                    if ($null -ne $skill) {
+                        $shiftSkills.Add($skill)
+                    }
+                }
+                $shift | Add-Member -MemberType NoteProperty -Name SkillNames -Value ($shiftSkills.name -join ';')
+
+                # Normalize start/end strings to yyyy-MM-dd from parsed dates
+                $shift.startAt = $shiftStart.ToString('yyyy-MM-dd')
+                if ($shift.endAt) {
+                    $shiftEnd = [DateTime]::ParseExact($shift.endAt, "MM/dd/yyyy HH:mm:ss", [System.Globalization.CultureInfo]::InvariantCulture).Date
+                    $shift.endAt = $shiftEnd.ToString('yyyy-MM-dd')
+                }
+
+                $contracts.Add($shift)
+            }
+
+            # Historical window
+            elseif ($shiftStart -ge $historyStartDate -and $shiftStart -le $historyEndDate) {
+                $historicalShiftContract['Shifts'].Add($shift)
             }
         }
 
+        # Person object
         $personObj = [PSCustomObject]@{
             ExternalId  = $worker.worker.workerNumber
-            DisplayName = "$($worker.worker.firstName) $($worker.worker.lastName) ($($worker.worker.workerNumber))".Trim(' ')
+            DisplayName = "$($worker.worker.firstName) $($worker.worker.lastName) ($($worker.worker.workerNumber))".Trim()
             FirstName   = $worker.worker.firstName
             LastName    = $worker.worker.lastName
             Email       = $worker.worker.email


### PR DESCRIPTION
## Summary
This update ensures that all `DateTime` values sent to HelloID are now converted to date-only values (`.Date`).  
This prevents unintended time components from being included in provisioning data.

## Details
- Converted all `DateTime` objects to date-only before passing them to HelloID.
- Updated `$shiftStart` and `$shiftEnd` parsing to explicitly return `.Date`.
- Refactored parts of the person script to accommodate these changes while maintaining the existing functionality.

## Impact
No functional changes to the data model, but eliminates potential mismatches caused by time values.

## Notes
This change has already been tested and successfully implemented in a production environment.